### PR TITLE
fix: add system theme detection and automatic theme switching

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -35,10 +35,27 @@ document.addEventListener('DOMContentLoaded', function() {
   // Initialize
   updateFileRows();
   
-  // Load saved theme or default to dark
-  const savedTheme = localStorage.getItem('gh-here-theme') || 'dark';
+  // Detect system theme preference
+  const systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const systemTheme = systemPrefersDark ? 'dark' : 'light';
+  
+  // Load saved theme or default to system preference
+  const savedTheme = localStorage.getItem('gh-here-theme') || systemTheme;
   html.setAttribute('data-theme', savedTheme);
   updateThemeIcon(savedTheme);
+  
+  // Listen for system theme changes (only if no manual override is saved)
+  if (window.matchMedia) {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    mediaQuery.addListener(function(e) {
+      // Only auto-update if user hasn't manually set a theme
+      if (!localStorage.getItem('gh-here-theme')) {
+        const newTheme = e.matches ? 'dark' : 'light';
+        html.setAttribute('data-theme', newTheme);
+        updateThemeIcon(newTheme);
+      }
+    });
+  }
   
   // Theme toggle functionality
   themeToggle.addEventListener('click', function() {


### PR DESCRIPTION
Fixes the dark/light mode toggle issue where the site remained in dark mode despite system theme changes.

## Changes
- Detect system theme preference using `prefers-color-scheme` media query
- Default to system theme instead of hardcoded dark mode
- Add event listener for system theme changes
- Automatically update theme when OS setting changes
- Preserve existing manual theme override functionality

## Behavior
- **Initial load**: App now matches your system theme (dark/light)
- **System theme changes**: App automatically follows when you toggle OS theme settings
- **Manual override**: Theme button still works and saves preference to localStorage
- **Persistent manual choice**: Once manually selected, theme sticks until localStorage is cleared

> dark and light mode doesn't seem to be working. I am toggling my system back and forth, but the site remains in dark mode. can you fix this?